### PR TITLE
Update sf_linux_os_syslog.py

### DIFF
--- a/source/lambda/es_loader/siem/sf_linux_os_syslog.py
+++ b/source/lambda/es_loader/siem/sf_linux_os_syslog.py
@@ -52,18 +52,18 @@ def extract_from_sshd(logdata, linux_dict):
         if ('accept' in data['action'].lower()
                 or 'isconnect' in data['action'].lower()
                 or 'opened' in data['action'].lower()):
-            logdata['event']['outcome'] = 'success'
+            linux_dict['event']['outcome'] = 'success'
         elif ('fail' in data['action'].lower()
                 or 'invalid' in data['action'].lower()
                 or 'err' in data['action'].lower()):
-            logdata['event']['outcome'] = 'failure'
+            linux_dict['event']['outcome'] = 'failure'
         elif ('isconnect' in data['action'].lower()
                 or 'reset' in data['action'].lower()
                 or 'close' in data['action'].lower()):
-            # logdata['event']['outcome'] is empty for disconnection event
+            # linux_dict['event']['outcome'] is empty for disconnection event
             pass
         else:
-            logdata['event']['outcome'] = 'unknown'
+            linux_dict['event']['outcome'] = 'unknown'
     return linux_dict
 
 


### PR DESCRIPTION
Changes `logdata` to `linux_dict` because `logdata` is not returned and not the right dict to update.

In the file `lambdas/loader/siem/sf_linux_os_syslog.py` the `extract_from_sshd` is updating the incorrect dict for `["event"]["outcome"]`. It should be `linux_dict` not `logdata` - please let me know if this is not correct.

I am currently writing unit tests on a forked copy of this code here: https://github.com/cds-snc/siem/pull/13 and hopefully can push them upstream when they are done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
